### PR TITLE
Fix deprecated subscriberCellularProvider

### DIFF
--- a/PhoneNumberKit/PhoneNumberKit.swift
+++ b/PhoneNumberKit/PhoneNumberKit.swift
@@ -296,7 +296,13 @@ public final class PhoneNumberKit: NSObject {
     public class func defaultRegionCode() -> String {
 #if os(iOS) && !targetEnvironment(simulator) && !targetEnvironment(macCatalyst)
         let networkInfo = CTTelephonyNetworkInfo()
-        let carrier = networkInfo.subscriberCellularProvider
+        var carrier: CTCarrier? = nil
+        if #available(iOS 12.0, *) {
+            carrier = networkInfo.serviceSubscriberCellularProviders?.values.first
+        } else {
+            carrier = networkInfo.subscriberCellularProvider
+        }
+
         if let isoCountryCode = carrier?.isoCountryCode {
             return isoCountryCode.uppercased()
         }


### PR DESCRIPTION
subscriberCellularProvider deprecated in iOS 12.0
https://developer.apple.com/documentation/coretelephony/cttelephonynetworkinfo/1616900-subscribercellularprovider